### PR TITLE
Implement SimpleHash NFT api routes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Thumbs.db
 
 # Next.js
 .next
+apps/site/.env.local

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Myflownfts
 
-## I. Installation
+## Installation
 
 ### Prerequisites
 
@@ -10,6 +10,10 @@
 
 #### Frontend Setup
 
-- `npm install -g yarn`
-- `yarn`
-- `nx serve site`
+- Create `/apps/site/.env.local` file and fill out `API_KEY`, which can be obtained from https://app.simplehash.com/.
+
+```
+npm install -g yarn
+yarn
+nx serve site
+```

--- a/apps/site/.env.local.example
+++ b/apps/site/.env.local.example
@@ -1,0 +1,2 @@
+# API key for SimpleHash
+API_KEY=

--- a/apps/site/src/api/index.ts
+++ b/apps/site/src/api/index.ts
@@ -1,0 +1,56 @@
+import { NFTListResponse } from './types';
+
+export const getNFTsByWallet = async (
+  walletAddresses: string,
+  chains = 'flow'
+): Promise<NFTListResponse> => {
+  const response = await fetch(
+    `/api/nfts/owners?chains=${chains}&wallet_addresses=${walletAddresses}`
+  );
+  const json = await response.json();
+  return json;
+};
+
+export const getNFTsByCollection = async (
+  collectionId: string
+): Promise<NFTListResponse> => {
+  const response = await fetch(`/api/nfts/collection/${collectionId}`);
+  const json = await response.json();
+  return json;
+};
+
+export const getNFTsByContract = async (
+  contractAddress: string,
+  chain = 'flow'
+): Promise<NFTListResponse> => {
+  const response = await fetch(
+    `/api/nfts?chain=${chain}&contract_address=${contractAddress}`
+  );
+  const json = await response.json();
+  return json;
+};
+
+export const getNFTsByTokenId = async (
+  contractAddress: string,
+  tokenId: string,
+  chain = 'flow'
+): Promise<NFTListResponse> => {
+  const response = await fetch(
+    `/api/nfts/token?chain=${chain}&contract_address=${contractAddress}&token_id=${tokenId}`
+  );
+  const json = await response.json();
+  return json;
+};
+
+export const getNFTs = async (chains = 'flow'): Promise<NFTListResponse> => {
+  const response = await fetch(`/api/nfts?chains=${chains}`);
+  const json = await response.json();
+  return json;
+};
+
+export const getRawQuery = async (url: string): Promise<NFTListResponse> => {
+  const newUrl = encodeURIComponent(url);
+  const response = await fetch(`/api/nfts?query=${newUrl}`);
+  const json = await response.json();
+  return json;
+};

--- a/apps/site/src/api/types.ts
+++ b/apps/site/src/api/types.ts
@@ -1,0 +1,69 @@
+export interface ListResponse<T> {
+  next?: string;
+  previous?: string;
+  data: T[];
+}
+
+export interface NFT {
+  nft_id: string;
+  chain: string;
+  contract_address: string;
+  token_id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  video_url: string;
+  audio_url?: string;
+  model_url: string;
+  previews: {
+    image_small_url: string;
+    image_medium_url: string;
+    image_large_url: string;
+    image_opengraph_url: string;
+    blurhash: string;
+  };
+  background_color?: string;
+  external_url: string;
+  created_date: string;
+  status: string; // minted
+  token_count: number;
+  owner_count: number;
+  owners: [
+    {
+      owner_address: string;
+      quantity: 1;
+      first_acquired_date: string;
+      last_acquired_date: string;
+    }
+  ];
+  last_sale: null;
+  contract: {
+    type: string; // NonFungibleToken
+    name: string;
+    symbol?: string;
+  };
+  collection: {
+    collection_id: string;
+    name: string;
+    description?: string;
+    image_url?: string;
+    banner_image_url?: string;
+    external_url?: string;
+    twitter_username?: string;
+    discord_url?: string;
+    marketplace_pages: [];
+    metaplex_mint?: string;
+    metaplex_first_verified_creator?: string;
+  };
+  extra_metadata: {
+    uuid: string;
+    serial_number: number;
+    edition_number: number;
+    max_editions: number;
+    creator_name: string;
+    image_original_url: string;
+    animation_original_url: string;
+  };
+}
+
+export type NFTListResponse = ListResponse<NFT>;

--- a/apps/site/src/constants.ts
+++ b/apps/site/src/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_API_URL = 'https://api.simplehash.com/api/v0';

--- a/apps/site/src/pages/api/nfts/collection/[id].ts
+++ b/apps/site/src/pages/api/nfts/collection/[id].ts
@@ -1,0 +1,30 @@
+import { fetchFromApi } from './../../utils';
+import { NFTListResponse } from '../../../../api/types';
+import { BASE_API_URL } from '../../../../constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NFTListResponse>
+): Promise<NextApiResponse<NFTListResponse>> {
+  if (req.method !== 'GET') {
+    return res.status(400);
+  }
+
+  const { id } = req.query;
+  const url = `${BASE_API_URL}/nfts/collection/${id}`;
+
+  await fetchFromApi(url)
+    .then((response) => response.json())
+    .then((response) => {
+      return res.status(200).json({
+        next: response.next,
+        previous: response.previous,
+        data: response.nfts,
+      });
+    })
+    .catch((err) => {
+      console.error(err);
+      return res.status(400);
+    });
+}

--- a/apps/site/src/pages/api/nfts/index.ts
+++ b/apps/site/src/pages/api/nfts/index.ts
@@ -1,0 +1,37 @@
+import { fetchFromApi } from './../utils';
+import { NFTListResponse } from './../../../api/types';
+import { BASE_API_URL } from '../../../constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NFTListResponse>
+) {
+  if (req.method !== 'GET') {
+    return res.status(400);
+  }
+
+  const { chain, chains, contract_address, query } = req.query;
+
+  let url = `${BASE_API_URL}/nfts?chains=${chains}`; // get all NFTs
+
+  if (query) {
+    url = query.toString(); // used for 'next' or 'previous' queries
+  } else if (chain && contract_address) {
+    url = `${BASE_API_URL}/nfts/${chain}/${contract_address}`; // get NFTs by Contract
+  }
+
+  await fetchFromApi(url)
+    .then((response) => response.json())
+    .then((response) => {
+      return res.status(200).json({
+        next: response.next,
+        previous: response.previous,
+        data: response.nfts,
+      });
+    })
+    .catch((err) => {
+      console.error(err);
+      return res.status(400);
+    });
+}

--- a/apps/site/src/pages/api/nfts/owners.ts
+++ b/apps/site/src/pages/api/nfts/owners.ts
@@ -1,0 +1,30 @@
+import { fetchFromApi } from './../utils';
+import { NFTListResponse } from './../../../api/types';
+import { BASE_API_URL } from '../../../constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NFTListResponse>
+): Promise<NextApiResponse<NFTListResponse>> {
+  if (req.method !== 'GET') {
+    return res.status(400);
+  }
+
+  const { chains, wallet_addresses } = req.query;
+  const url = `${BASE_API_URL}/nfts/owners?chains=${chains}&wallet_addresses=${wallet_addresses}`;
+
+  await fetchFromApi(url)
+    .then((response) => response.json())
+    .then((response) => {
+      return res.status(200).json({
+        next: response.next,
+        previous: response.previous,
+        data: response.nfts,
+      });
+    })
+    .catch((err) => {
+      console.error(err);
+      return res.status(400);
+    });
+}

--- a/apps/site/src/pages/api/nfts/token.ts
+++ b/apps/site/src/pages/api/nfts/token.ts
@@ -1,0 +1,27 @@
+import { fetchFromApi } from './../utils';
+import { NFT } from '../../../api/types';
+import { BASE_API_URL } from '../../../constants';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NFT>
+) {
+  if (req.method !== 'GET') {
+    return res.status(400);
+  }
+
+  const { chain, contract_address, token_id } = req.query;
+
+  const url = `${BASE_API_URL}/nfts/${chain}/${contract_address}/${token_id}`;
+
+  await fetchFromApi(url)
+    .then((response) => response.json())
+    .then((response) => {
+      return res.status(200).json(response);
+    })
+    .catch((err) => {
+      console.error(err);
+      return res.status(400);
+    });
+}

--- a/apps/site/src/pages/api/utils.ts
+++ b/apps/site/src/pages/api/utils.ts
@@ -1,0 +1,9 @@
+export const fetchFromApi = async (url: string) => {
+  return fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'X-API-KEY': process.env.API_KEY,
+    },
+  });
+};


### PR DESCRIPTION
```tsx
// sample usage
  useEffect(() => {
    (async () => {
      // const response = await getNFTsByWallet('0x178c179549219f56');
      // const { next, data, previous } = await getNFTsByCollection(
      //   '3ba5edf6e8383cf791c285d284de3546'
      // );
      // const response = await getNFTsByContract('A.329feb3ab062d289.UFC_NFT');
      // const response = await getNFTsByTokenId(
      //   'A.329feb3ab062d289.UFC_NFT',
      //   '91055'
      // );
      const { next, data, previous } = await getNFTs();
      console.log(next);
      console.log(previous);
      console.log(data);
      const {
        next: next2,
        data: data2,
        previous: previous2,
      } = await getRawQuery(next);

      console.log('next query');
      console.log(next2);
      console.log(previous2);
      console.log(data2);
    })();
  }, []);
```