### PR TITLE
Implement layout fixes

### DIFF
--- a/apps/site/src/components/PageLanding/index.tsx
+++ b/apps/site/src/components/PageLanding/index.tsx
@@ -12,7 +12,7 @@ import bgCommunityFeaturedMobile from './images/community-featured/bg-community-
 import bgCommunityFeatured from './images/community-featured/bg-community-featured.png';
 import Intro from './Intro';
 import Partners from './Partners';
-import Signup from './Signup';
+// import Signup from './Signup';
 
 export default function PageLanding() {
   const { t } = useTranslation();
@@ -67,7 +67,7 @@ export default function PageLanding() {
           <Communities />
           <Featured />
         </div>
-        <Signup />
+        {/* <Signup /> */}
         <Footer />
       </div>
     </>

--- a/apps/site/src/components/PageViewNFT/index.tsx
+++ b/apps/site/src/components/PageViewNFT/index.tsx
@@ -658,7 +658,7 @@ export default function PageViewNFT() {
         )}
 
         {!isLoading && token?.nft_id && token?.image_url && (
-          <div className="flex flex-col items-end h-fit pt-28 place-self-center min-h-[50rem] w-11/12 max-w-[125rem] lg:pr-24">
+          <div className="flex flex-col items-end h-fit pt-28 place-self-center min-h-[calc(100vh-11.5rem)] w-11/12 max-w-[125rem] lg:pr-24">
             {renderButtons()}
             <div className="flex flex-col lg:flex-row w-full h-full gap-6 lg:gap-[10.375rem]">
               <div className="flex justify-center w-full pt-2 mx-auto lg:pt-0 lg:w-1/2 lg:items-start lg:justify-end lg:pb-16 h-5/6">

--- a/apps/site/src/components/PageViewNFT/index.tsx
+++ b/apps/site/src/components/PageViewNFT/index.tsx
@@ -279,7 +279,9 @@ export default function PageViewNFT() {
         </div>
       </div>
       <span className="font-semibold text-white text-h3">
-        {token?.name ?? token.contract.name + ' #' + token.token_id}
+        {token?.name && token?.name !== token?.contract.name
+          ? token.name
+          : token.contract.name + ' #' + token.token_id}
       </span>
       <span className="font-medium text-white whitespace-pre-line text-footer font-body">
         {token.description ?? t('pages.viewNFT.noDescription')}
@@ -672,7 +674,7 @@ export default function PageViewNFT() {
 
         <Footer
           className={classNames(
-            'pt-12 pb-12',
+            'mt-12',
             (isLoading ||
               (token?.nft_id && !token?.name && !token?.image_url) ||
               !token?.nft_id) &&

--- a/apps/site/src/components/PageViewNFTs/index.tsx
+++ b/apps/site/src/components/PageViewNFTs/index.tsx
@@ -175,7 +175,11 @@ export default function PageViewNFTs() {
                 'Unknown'
               }
               token_id={item.token_id}
-              name={item.name ?? item.token_id}
+              name={
+                item?.name && item?.name !== item?.contract.name
+                  ? item.name
+                  : item.contract.name + ' #' + item.token_id
+              }
               image_url={item.previews.image_small_url ?? '/not_supported.png'} // Error if no unknown
               url={`/nft/${item.contract_address}/${item.token_id}`}
               variant="view"

--- a/apps/site/src/components/common/NFTCard/index.tsx
+++ b/apps/site/src/components/common/NFTCard/index.tsx
@@ -127,7 +127,7 @@ export default function NFTCard({
             variant === 'view' && 'pt-1.5 text-mobile-sm lg:text-tab'
           )}
         >
-          {name ?? contract + ' #' + token_id}
+          {name && name !== contract ? name : contract + ' #' + token_id}
         </span>
       </div>
     </Button>


### PR DESCRIPTION
- Add top margin to footer on `viewNFT` page
- Change `viewNFTs` alternate token `name` from `token_id` to `contract+" #"+token_id` 
- Hide signup banner
- Add name filter
  ```
   if token.name === contract_name
      display contract_name+" #"+token_id ---> Fixes issue with `Flunks` having the same names
   ```